### PR TITLE
Adds method to output read time for a given blog post. 

### DIFF
--- a/trello2scrambledbits.rb
+++ b/trello2scrambledbits.rb
@@ -36,6 +36,14 @@ class Manager < Thor
     puts markdown
   end
 
+  desc 'readingtime [boardid]', 'Fetch trello board and estimate reading time.'
+  def readingtime(board_id=nil)
+    board = fetch_board(board_id)
+    markdown = get_markdown_for_board(board)
+    numwords = markdown.split(' ').length 
+    puts "Estimated reading time: " + (numwords / 200).to_s + " minutes"
+  end
+
   desc 'tomedium [boardid]', 'Fetch trello board and send results to Medium.'
   def tomedium(board_id=nil)
     begin


### PR DESCRIPTION
This pull request adds a new method allowing users to generate an approximate read time without pushing all of the content up to Medium. This is done with a simple method that takes the word count of the generated markdown and divides it by the average reading speed (200 words per second) outputting that value to the console when the `readtime` command is called. The method takes the board ID to generate a reading estimate. 